### PR TITLE
Fix build: explicit version of 'cookie' crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/SkylerLipthay/oatmeal_raisin"
 
 [dependencies]
-cookie = "*"
-iron = "*"
-persistent = "*"
-plugin = "*"
+cookie = "0.1"
+iron = "0.2"
+persistent = "0.0"
+plugin = "0.2"


### PR DESCRIPTION
This would pull in both 'cookie v0.1.21' and 'cookie v0.2.0'.
I've pinned all used dependencies to the current versions (x.y),
except for cookie, which is at '0.1'.
